### PR TITLE
fix(android, build): remove jcenter / use modern versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,6 @@ repositories {
         url "$rootDir/../node_modules/jsc-android/dist"
     }
     google()
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
Hi there!

This is the version of the `build.gradle` that I'm using via `patch-package` in my project, thought it would be good to make a PR for everyone